### PR TITLE
Fix: don't run SauceLabs tests on PR's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
 script:
   - 'npm test'
   - 'npm run coveralls'
-  - '[ "${TRAVIS_PULL_REQUEST}" = "true" ] || npm run saucelabs'
+  - '[ "${TRAVIS_PULL_REQUEST}" != "false" ] || npm run saucelabs'
 after_script:
   - 'cat $LOGS_DIR/karma.log'
 env:


### PR DESCRIPTION
Testing CI stuff is hard… ;) Doing this as my own PR now so I can amend commits until it works as expected.

I should’ve read the docs better: “The environment variable ${TRAVIS_PULL_REQUEST} is set to "false" when the build is for a normal branch commit. When the build is for a pull request, it will contain the pull request’s number.”

Resources:
http://docs.travis-ci.com/user/pull-requests/#Security-Restrictions-when-testing-Pull-Requests

Fixes #31