### PR TITLE
feat(apiMock): default mock setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,14 @@ Configure is done through `apiMockProvider.config()`. Add this to your AngularJS
 });
 ````
 
+#### defaultMock
+
+Type: `boolean/string/number`
+
+Default: `false`
+
+Sets a default mock value. See [apiMock values](#apimock).
+
 #### mockDataPath
 
 Type: `string`

--- a/app/scripts/angular-apimock.js
+++ b/app/scripts/angular-apimock.js
@@ -43,6 +43,7 @@ angular.module('apiMock', [])
 		var $log;
 		var $q;
 		var config = {
+			defaultMock: false,
 			mockDataPath: '/mock_data',
 			apiPath: '/api',
 			disable: false,
@@ -163,8 +164,12 @@ angular.module('apiMock', [])
 
 		function getParameter(req) {
 			var mockValue = localMock(req);
+			// Note: `false` is a valid option, so we can't use falsy-checks.
 			if (mockValue === undefined) {
 				mockValue = globalMock();
+			}
+			if (mockValue === undefined) {
+				mockValue = config.defaultMock;
 			}
 
 			return mockValue;

--- a/test/spec/services/angular-apimock.js
+++ b/test/spec/services/angular-apimock.js
@@ -91,9 +91,9 @@ describe('Service: apiMock', function () {
 		function expectHttpFailure(doneCb, failCb) {
 			$httpBackend.expect(defaultExpectMethod, defaultExpectPath).respond(404);
 
-			$http(defaultRequest)
+			$http(defaultRequest) // TODO: Callbacks isn't the proper way to test $http. It also doesn't seem to test properly as we can switch expectHttpSuccess() and expectHttpFailure() without tests failing.
 				.success(function () {
-					fail(); // Todo: How to fail the test if this happens?
+					fail();
 					failCb && failCb();
 				})
 				.error(function (data, status) {
@@ -107,7 +107,7 @@ describe('Service: apiMock', function () {
 
 		function expectHttpSuccess(doneCb, failCb) {
 			$httpBackend.expect(defaultExpectMethod, defaultExpectPath).respond({});
-			$http(defaultRequest)
+			$http(defaultRequest) // TODO: Callbacks isn't the proper way to test $http. It also doesn't seem to test properly as we can switch expectHttpSuccess() and expectHttpFailure() without tests failing.
 				.success(function () {
 					doneCb && doneCb();
 				})
@@ -381,7 +381,7 @@ describe('Service: apiMock', function () {
 
 				describe('off', function () {
 
-					it('should explicitly behave as usual with falsy values', function () {
+					it('should not mock with falsy values', function () {
 						// Define falsy values.
 						var values = [
 							false,
@@ -418,6 +418,16 @@ describe('Service: apiMock', function () {
 					apiMockProvider.config({disable: false});
 				});
 
+				it('should override config default mock', function () {
+					apiMockProvider.config({defaultMock: true});
+
+					// Test connection.
+					expectMockDisabled();
+					expectHttpFailure();
+
+					unsetGlobalCommand();
+				});
+
 				it('should override command mock', function () {
 					setGlobalCommand(true);
 
@@ -438,6 +448,51 @@ describe('Service: apiMock', function () {
 					unsetGlobalCommand();
 				});
 
+			});
+
+			describe('default mock option', function () {
+				beforeEach(function () {
+					//apiMockProvider.config({defaultMock: true});
+				});
+
+				afterEach(function () {
+					apiMockProvider.config({defaultMock: false});
+					unsetGlobalCommand();
+				});
+
+				it('should mock even without global or local flag', function () {
+					apiMockProvider.config({defaultMock: true});
+
+					// Test connection.
+					expectMockEnabled();
+					expectHttpSuccess();
+				});
+
+				it('should be overriden by global flag', function () {
+					apiMockProvider.config({defaultMock: true});
+					setGlobalCommand(false);
+
+					// Test connection.
+					expectMockDisabled();
+					expectHttpFailure();
+				});
+
+				it('should be overriden by local flag', function () {
+					apiMockProvider.config({defaultMock: true});
+					defaultRequest.apiMock = false;
+
+					// Test connection.
+					expectMockDisabled();
+					expectHttpFailure();
+				});
+
+				it('should not mock when set to false', function () {
+					apiMockProvider.config({defaultMock: false});
+
+					// Test connection.
+					expectMockDisabled();
+					expectHttpFailure();
+				});
 			});
 
 			describe('allow regexp for apiPath option instead of string', function () {


### PR DESCRIPTION
It should work for all commands, but tests only test for `true` for
now. Need to refactor the tests and code so we don’t need so much
repeat tests for the various commands.

Closes #24