### PR TITLE
chore(travis): update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
+sudo: false
 language: node_js
 node_js:
   - '0.12'
+cache:
+  directories:
+  - node_modules
+  - app/bower_components
 before_install:
   - 'npm install -g bower grunt-cli'
 before_script:


### PR DESCRIPTION
Use new Travis container based infrastructure.
As according to http://docs.travis-ci.com/user/migrating-from-legacy/

Cache npm and Bower directories. Hopefully get some build speed improvement, but just good practice otherwise. We should start with npm-shrinkwrap or something to avoid local updates that aren't picked up by Travis because of the caching.

Resources:
http://docs.travis-ci.com/user/caching/#Fetching-and-storing-caches
http://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dep
endencies/

Closes #34