### PR TITLE
chore(grunt): add nodesecurity.io task

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -336,9 +336,9 @@ module.exports = function (grunt) {
 	]);
 
 	grunt.registerTask('publish', [ 'publish:patch' ]);
-	grunt.registerTask('publish:patch', [ 'test', 'karma:sauce', 'bump-only:patch', '_publish' ]);
-	grunt.registerTask('publish:minor', [ 'test', 'karma:sauce', 'bump-only:minor', '_publish' ]);
-	grunt.registerTask('publish:major', [ 'test', 'karma:sauce', 'bump-only:major', '_publish' ]);
+	grunt.registerTask('publish:patch', [ 'validate-package', 'test', 'karma:sauce', 'bump-only:patch', '_publish' ]);
+	grunt.registerTask('publish:minor', [ 'validate-package', 'test', 'karma:sauce', 'bump-only:minor', '_publish' ]);
+	grunt.registerTask('publish:major', [ 'validate-package', 'test', 'karma:sauce', 'bump-only:major', '_publish' ]);
 
 	grunt.registerTask('default', [
 		'test'

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "grunt-newer": "^1.1.0",
     "grunt-ng-annotate": "^1.0.1",
     "grunt-npm": "0.0.2",
+    "grunt-nsp-package": "0.0.5",
     "grunt-nuget": "^0.1.3",
     "jasmine": "^2.3.2",
     "jasmine-core": "^2.3.4",


### PR DESCRIPTION
We only use node for build tasks, so auditing the package.json for
security vulnerabilities isn’t actually needed but it’s interesting
anyway.

Closes #52 