### PR TITLE
fix(apimock): timestamps had an invalid format

### DIFF
--- a/app/scripts/angular-apimock.js
+++ b/app/scripts/angular-apimock.js
@@ -84,8 +84,8 @@ angular.module('apiMock', [])
 				'-' + pad(date.getUTCMonth() + 1) +
 				'-' + pad(date.getUTCDate()) +
 				'T' + pad(date.getUTCHours()) +
-				':' + pad(date.getUTCMinutes()) +
-				':' + pad(date.getUTCSeconds()) +
+				'.' + pad(date.getUTCMinutes()) +
+				'.' + pad(date.getUTCSeconds()) +
 				'.' + (date.getUTCMilliseconds() / 1000).toFixed(3).slice(2, 5) +
 				'Z';
 		}

--- a/test/spec/services/angular-apimock.js
+++ b/test/spec/services/angular-apimock.js
@@ -748,9 +748,9 @@ describe('Service: apiMock', function () {
 				it('should serialize date type', function () {
 					defaultRequest.url = '/api/pokemon';
 					defaultRequest.params = {
-						'releaseDate': new Date(Date.UTC(96, 1, 27, 0, 0, 0))
+						'releaseDate': new Date(Date.UTC(96, 1, 27, 1, 2, 3))
 					};
-					defaultExpectPath = '/mock_data/pokemon/releasedate=1996-02-27t00:00:00.000z.get.json';
+					defaultExpectPath = '/mock_data/pokemon/releasedate=1996-02-27t01.02.03.000z.get.json';
 
 					expectHttpSuccess();
 				});


### PR DESCRIPTION
`00:00:00` isn’t a valid filename. Using `00.00.00` instead.

Fixes #57